### PR TITLE
ignore directories/files config

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -36,6 +36,6 @@ module.exports = function(grunt) {
   });
 
   // Default task.
-  grunt.registerTask('default', 'lint test');
+  grunt.registerTask('default', 'test');
 
 };

--- a/test/importless_test.coffee
+++ b/test/importless_test.coffee
@@ -73,6 +73,16 @@ exports['stripImported'] =
     test.deepEqual importless.stripImported(files, importless.getImported(files)), ['test/files/test.less', 'test/files/test2.css']
     test.done()
 
+exports['setIgnored'] = 
+  'ignore `ignore` directory when set': (test) ->
+    test.expect 1
+    importless.setIgnored '**/test2.*'
+    files = importless.findAll 'test/files'
+    test.deepEqual importless.stripIgnored(files, importless.getIgnored()), ['test/files/imported.less', 'test/files/test.less']
+    importless.setIgnored []
+    test.done()
+
+
 exports['detectDependencies'] = 
   setUp: (next) ->
     next()


### PR DESCRIPTION
importless needs an option to ignore certain directories or files (e.g. `node_modules`).
